### PR TITLE
Adds set projectID from october.yaml on install 

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -107,6 +107,7 @@ class InstallCommand extends Command
         $this->output = $output;
         $this->pluginManager->setOutput($output);
         $this->themeManager->setOutput($output);
+        $this->composer->setOutput($output);
     }
 
     /**
@@ -286,13 +287,15 @@ class InstallCommand extends Command
                 if ($pluginInstalled && $remote) {
                     $this->write("Removing ${vendor}.${plugin} directory to re-download the newest version...",
                         'comment');
+
+                    $this->pluginManager->removeDir($pluginDeclaration);
+                    $installPlugin = true;
+                }
+                else {
+                    $installPlugin = false;
+                    $this->write("-> Skipping re-downloading of ${vendor}.${plugin}", 'comment');
                 }
 
-                $this->pluginManager->removeDir($pluginDeclaration);
-                $installPlugin = true;
-            } else {
-                $installPlugin = false;
-                $this->write("-> Skipping re-downloading of ${vendor}.${plugin}", 'comment');
             }
 
             if ($installPlugin) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -212,6 +212,11 @@ class InstallCommand extends Command
             }
         }
 
+        if($this->config->projectID){
+            $this->write('Setting Project ID...');
+            $this->artisan->call('october:util set project --projectId='.$this->config->projectID);
+        }
+
         $pluginsDeclarations = [];
         try {
             $pluginsDeclarations = $this->config->plugins;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -212,9 +212,9 @@ class InstallCommand extends Command
             }
         }
 
-        if($this->config->projectID){
+        if($this->config->project){
             $this->write('Setting Project ID...');
-            $this->artisan->call('october:util set project --projectId='.$this->config->projectID);
+            $this->artisan->call('october:util set project --projectId='.$this->config->project);
         }
 
         $pluginsDeclarations = [];

--- a/src/Util/Composer.php
+++ b/src/Util/Composer.php
@@ -6,6 +6,7 @@ namespace OFFLINE\Bootstrapper\October\Util;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class Composer
@@ -21,12 +22,27 @@ class Composer
     protected $composer;
 
     /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+
+    /**
      * Run Composer commands.
      */
     public function __construct()
     {
         $this->composer = $this->findComposer();
     }
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function setOutput($output)
+    {
+        $this->output = $output;
+    }
+
 
     /**
      * Get the composer command for the environment.


### PR DESCRIPTION
Sets Project ID from within install command to allow installation of purchased plugins from october store. 

Fixes #18 

I had to fix two bugs in the InstallerCommand to test this.