### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/composer:latest
+FROM composer:latest
 
 RUN apk add --no-cache \
     curl \
@@ -20,8 +20,8 @@ RUN mkdir /composer
 
 WORKDIR /composer
 
-RUN composer require --prefer-dist laravel/envoy --no-interaction
-RUN composer require --prefer-dist offline/oc-bootstrapper --no-interaction
+RUN composer global require --prefer-dist hirak/prestissimo --no-interaction
+RUN composer require --prefer-dist laravel/envoy offline/oc-bootstrapper --no-interaction
 
 RUN ln -s /composer/vendor/bin/october /usr/bin/october
 RUN ln -s /composer/vendor/bin/envoy /usr/bin/envoy

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk add --no-cache \
                 curl \
                 curl-dev \
         libcurl \
-        libssl1.0 \
         libxml2-dev     \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:latest
+FROM arm32v7/composer:latest
 
 RUN apk add --no-cache \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,15 @@ RUN docker-php-ext-install pdo \
     zip \
     posix
 
-RUN mkdir /tmp/bootstrapper /build
+RUN mkdir /composer
 
-RUN composer global require --prefer-dist laravel/envoy --no-interaction
+WORKDIR /composer
 
-ADD . /tmp/bootstrapper
+RUN composer require --prefer-dist laravel/envoy --no-interaction
+RUN composer require --prefer-dist offline/oc-bootstrapper --no-interaction
 
-WORKDIR /tmp/bootstrapper
-RUN composer install --no-interaction --prefer-dist
-
-RUN ln -s /tmp/bootstrapper/october /usr/bin/october
-RUN ln -s /tmp/vendor/bin/envoy /usr/bin/envoy
-
-WORKDIR /build
+RUN ln -s /composer/vendor/bin/october /usr/bin/october
+RUN ln -s /composer/vendor/bin/envoy /usr/bin/envoy
 
 ENTRYPOINT []
-CMD ["/tmp/bootstrapper/october"]
+CMD ["/composer/vendor/bin/october"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache \
                 curl \
                 curl-dev \
         libcurl \
+        libssl1.1 \
         libxml2-dev     \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
 FROM composer:latest
 
 RUN apk add --no-cache \
-                curl \
-                curl-dev \
-        libcurl \
-        libssl1.1 \
-        libxml2-dev     \
+    curl \
+    curl-dev \
+    libcurl \
+    libssl1.1 \
+    libxml2-dev \
+    libzip-dev \
     && rm -rf /var/cache/apk/*
 
-
-RUN docker-php-ext-install pdo
-RUN docker-php-ext-install pdo_mysql
-RUN docker-php-ext-install curl
-RUN docker-php-ext-install xml
-RUN docker-php-ext-install zip
-RUN docker-php-ext-install posix
+RUN docker-php-ext-install pdo \
+    pdo_mysql \
+    curl \
+    xml \
+    zip \
+    posix
 
 RUN mkdir /tmp/bootstrapper /build
 
@@ -32,5 +32,3 @@ WORKDIR /build
 
 ENTRYPOINT []
 CMD ["/tmp/bootstrapper/october"]
-
-


### PR DESCRIPTION
Here is a faster building image of Docker image. I have also added global [hirak/prestissimo](https://github.com/hirak/prestissimo) as it's fastening using composer ten times. Remove it if you don't like it.

`envoy` and `october` commands work as they worked. 

I used the Dockerfile (only changed the starting image to [arm32v7/composer](https://hub.docker.com/r/arm32v7/composer)) to build the ARM compatible image [here](https://cloud.docker.com/u/initbiz/repository/docker/initbiz/oc-bootstrapper-arm32v7) of the oc-bootstrapper.