### PR TITLE
Disable core updates by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ app:
 cms:
     theme: name (user@remote.git)
     edgeUpdates: false
+    disableCoreUpdates: true
     enableSafeMode: false
     # project: XXXX            # Marketplace project ID
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ app:
 cms:
     theme: name (user@remote.git)
     edgeUpdates: false
-    disableCoreUpdates: true
+    disableCoreUpdates: false
     enableSafeMode: false
     # project: XXXX            # Marketplace project ID
 

--- a/src/Config/Setup.php
+++ b/src/Config/Setup.php
@@ -83,6 +83,7 @@ class Setup
             'APP_ENV'         => 'dev',
             '',
             'CMS_SAFE_MODE'   => $this->getSafeMode(),
+            'CMS_DISABLE_CORE_UPDATES' => (bool)$this->config->cms['disableCoreUpdates'] ? 'true' : 'false',
             '',
             'DB_CONNECTION'   => $this->config->database['connection'],
             'DB_HOST'         => $this->config->database['host'],
@@ -161,6 +162,7 @@ class Setup
     {
         $values = [
             'enableSafeMode' => "env('CMS_SAFE_MODE', " . $this->getSafeMode() . ')',
+            'disableCoreUpdates' => "env('CMS_DISABLE_CORE_UPDATES', true)",
         ];
 
         $this->writer->write('cms', $values);

--- a/src/Config/Setup.php
+++ b/src/Config/Setup.php
@@ -83,7 +83,7 @@ class Setup
             'APP_ENV'         => 'dev',
             '',
             'CMS_SAFE_MODE'   => $this->getSafeMode(),
-            'CMS_DISABLE_CORE_UPDATES' => (bool)$this->config->cms['disableCoreUpdates'] ? 'true' : 'false',
+            'CMS_DISABLE_CORE_UPDATES' => (isset($this->config->cms['disableCoreUpdates']) && $this->config->cms['disableCoreUpdates'] === true) ? 'true' : 'false',
             '',
             'DB_CONNECTION'   => $this->config->database['connection'],
             'DB_HOST'         => $this->config->database['host'],
@@ -162,7 +162,7 @@ class Setup
     {
         $values = [
             'enableSafeMode' => "env('CMS_SAFE_MODE', " . $this->getSafeMode() . ')',
-            'disableCoreUpdates' => "env('CMS_DISABLE_CORE_UPDATES', true)",
+            'disableCoreUpdates' => "env('CMS_DISABLE_CORE_UPDATES', false)",
         ];
 
         $this->writer->write('cms', $values);

--- a/templates/october.yaml
+++ b/templates/october.yaml
@@ -6,6 +6,7 @@ app:
 cms:
     theme: name (user@remote.git)
     edgeUpdates: false
+    disableCoreUpdates: true
     enableSafeMode: false
 
 database:

--- a/templates/october.yaml
+++ b/templates/october.yaml
@@ -6,7 +6,7 @@ app:
 cms:
     theme: name (user@remote.git)
     edgeUpdates: false
-    disableCoreUpdates: true
+    disableCoreUpdates: false
     enableSafeMode: false
 
 database:


### PR DESCRIPTION
Fixes https://github.com/OFFLINE-GmbH/oc-bootstrapper/issues/39.

This makes `disableCoreUpdates` in the `config/cms.php` file true by default, allowing for Composer to manage October CMS updates.

Thanks guys for the great utility!