### PR TITLE
Composer 2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN mkdir /composer
 
 WORKDIR /composer
 
-RUN composer global require --prefer-dist hirak/prestissimo --no-interaction
 RUN composer require --prefer-dist laravel/envoy offline/oc-bootstrapper --no-interaction
 
 RUN ln -s /composer/vendor/bin/october /usr/bin/october

--- a/october
+++ b/october
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 define('DS', DIRECTORY_SEPARATOR);
-define('VERSION', '0.9.1');
+define('VERSION', '1.0.0');
 
 if (file_exists(__DIR__.'/../../autoload.php')) {
     require __DIR__.'/../../autoload.php';

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -181,9 +181,9 @@ class InstallCommand extends Command
 
         $this->gitignore = new Gitignore($this->getGitignore());
 
-        $this->write('Downloading latest October CMS...');
+        $this->write('Installing latest October CMS...');
         try {
-            (new OctoberCms())->download($this->force);
+            (new OctoberCms($this->composer))->install($this->force);
         } catch (\LogicException $e) {
             $this->write($e->getMessage(), 'comment');
         } catch (Throwable $e) {
@@ -194,9 +194,6 @@ class InstallCommand extends Command
 
         $this->write('Patching composer.json...');
         $this->patchComposerJson();
-
-        $this->write('Installing composer dependencies...');
-        $this->composer->install();
 
         $this->write('Setting up config files...');
         $this->writeConfig($this->force);
@@ -242,6 +239,10 @@ class InstallCommand extends Command
             $this->write('Installing Plugins...');
             $this->installPlugins($pluginsDeclarations);
         }
+
+        // Plugins may have composer dependencies, so install them now...
+        $this->write('Installing composer dependencies...');
+        $this->composer->install();
 
         $deployment = false;
         try {

--- a/src/Util/Composer.php
+++ b/src/Util/Composer.php
@@ -150,4 +150,25 @@ class Composer
             3600
         );
     }
+
+    /**
+     * Composer create-project <project> <path> <version>
+     *
+     * @return void
+     * @throws LogicException
+     * @throws RuntimeException
+     * @throws InvalidArgumentException
+     */
+    public function createProject($project, $path, $version)
+    {
+        $project = escapeshellarg($project);
+        $path = escapeshellarg($path);
+        $version = escapeshellarg($version);
+
+        $this->runProcess(
+            $this->composer . ' create-project ' . $project . ' ' . $path . ' ' . $version . ' --no-interaction',
+            'Failed to create the composer project',
+            3600
+        );
+    }
 }


### PR DESCRIPTION
Initial attempt to fix #50 

- Use `composer create-project october/october` to install october. This is the new preferred way to install October from version `1.1.0` on. It also requires less hacks, e.g. to load the `.htaccess` file and works with Composer 2.
- Bump the installed October version to `1.1.*` (Maybe this can be automated or configurable?)
- Install additional composer dependecies after plugins have been installed. Reason: If a plugin is installed via git remote and does have composer dependencies, those are only installed if we run `composer install` after the installation.
- Bump to a new major version `1.0.0`. Probably it is a good idea to have a separate branch for this version?